### PR TITLE
Fix the ifNoneExist example

### DIFF
--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -138,7 +138,7 @@ When submitting CGM data, there are two complementary approaches for handling po
 1. **Client-Controlled Deduplication With Conditional Create**
    - Clients MAY include `ifNoneExist` elements in Bundle.entry.request
    - Clients MAY adopt any strategy for generating Identifiers, including strategies to deterministically create identifiers based on the instance data
-   - Example of Bundle.entry.request.ifNoneExists: `identifier=https://client.example.org|123`
+   - Example of Bundle.entry.request.ifNoneExist: `identifier=https://client.example.org|123`
    - Servers SHOULD support conditional create requests
    - Servers SHOULD persist client-supplied identifiers to support this pattern
    - When supporting conditional creates, servers:

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -138,7 +138,7 @@ When submitting CGM data, there are two complementary approaches for handling po
 1. **Client-Controlled Deduplication With Conditional Create**
    - Clients MAY include `ifNoneExist` elements in Bundle.entry.request
    - Clients MAY adopt any strategy for generating Identifiers, including strategies to deterministically create identifiers based on the instance data
-   - Example of Bundle.entry.request.ifNoneExists: `Observation?identifier=https://client.example.org|123`
+   - Example of Bundle.entry.request.ifNoneExists: `identifier=https://client.example.org|123`
    - Servers SHOULD support conditional create requests
    - Servers SHOULD persist client-supplied identifiers to support this pattern
    - When supporting conditional creates, servers:

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -138,7 +138,7 @@ When submitting CGM data, there are two complementary approaches for handling po
 1. **Client-Controlled Deduplication With Conditional Create**
    - Clients MAY include `ifNoneExist` elements in `Bundle.entry.request`
    - Clients MAY adopt any strategy for generating Identifiers, including strategies to deterministically create identifiers based on the instance data
-   - Example of `Bundle.entry.request.ifNoneExist`: `Observation?identifier=https://client.example.org|123`
+   - Example of `Bundle.entry.request.ifNoneExist`: `identifier=https://client.example.org|123`
    - Servers SHOULD support conditional create requests
    - Servers SHOULD persist client-supplied identifiers to support this pattern
    - When a server supports conditional creates, it:


### PR DESCRIPTION
See https://jira.hl7.org/browse/FHIR-48995.

The element name is `ifNoneExist`, not `ifNoneExists`. And the value is expected to only contain the query parameters, not the resource type. See [the spec](https://hl7.org/fhir/R4B/http.html#ccreate):

> The parameter just contains the search parameters (what would be in the URL following the "?").